### PR TITLE
Fixed app metrics

### DIFF
--- a/js/libs.js
+++ b/js/libs.js
@@ -797,6 +797,21 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
     renderData(periodInSeconds, context)
   }
 
+  function normalizeAggregatedData(data, type) {
+    var prior = data[0];
+    var current = data[1];
+    return [{
+      count: prior.data.map(function (x) { return +x[type] }).reduce(function (a, b) { return a + b }, 0),
+      periodStart: prior.periodStart,
+      periodEnd: prior.periodEnd,
+    },
+    {
+      count: current.data.map(function (x) { return +x[type] }).reduce(function (a, b) { return a + b }, 0),
+      periodStart: current.periodStart,
+      periodEnd: current.periodEnd,
+    }]
+  }
+
   function renderData(periodInSeconds, context) {
     // RENDER APP METRICS
     var appMetricsArrayData = [];
@@ -1124,6 +1139,8 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
         from: moment(priorPeriodStartDate).format('YYYY-MM-DD'),
         to: moment(currentPeriodEndDate).format('YYYY-MM-DD'),
         sum: 'uniqueSessions'
+      }).then(function (results) { 
+        return normalizeAggregatedData(results, 'uniqueSessions')
       });
 
       metricScreenViews = Fliplet.App.Analytics.Aggregate.get({
@@ -1131,13 +1148,18 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
         from: moment(priorPeriodStartDate).format('YYYY-MM-DD'),
         to: moment(currentPeriodEndDate).format('YYYY-MM-DD'),
         sum: 'totalPageViews'
+      }).then(function (results) { 
+        return normalizeAggregatedData(results, 'totalPageViews')
       });
+
 
       metricInteractions = Fliplet.App.Analytics.Aggregate.get({
         period: Math.floor(periodDurationInSeconds / 1000 / (3600*24)), // in days
         from: moment(priorPeriodStartDate).format('YYYY-MM-DD'),
         to: moment(currentPeriodEndDate).format('YYYY-MM-DD'),
         sum: 'totalEvents'
+      }).then(function (results) { 
+        return normalizeAggregatedData(results, 'totalEvents')
       });
     }
 


### PR DESCRIPTION
We needed some extra aggregation so the `uniqueSessions`, `totalPageViews` and `totalEvents` **app metrics** for periods other than the `last 24 hours` one visualised. (right now they are empty).
The metrics showed when filtered by `last 24 hours` because the data structure returned was different than the one returned for all other types.
Data structure for the `last 7 days`
```
[
  {
    "metricActiveDevicesPrior": 6060,
    "metricActiveDevices": 0
  },
  {
    "metricNewDevicesPrior": 3759,
    "metricNewDevices": 0
  },
  [
    {
      "periodStart": "2018-12-19",
      "periodEnd": "2018-12-25",
      "data": [
        {
          "day": "2018-12-19",
          "totalDevices": "2676",
          "uniqueDevices": "2301",
          "totalSessions": "2676",
          "uniqueSessions": "2034",
          "totalPageViews": "2518",
          "totalEvents": "158"
        },
        {
          "day": "2018-12-20",
          "totalDevices": "2478",
          "uniqueDevices": "2186",
          "totalSessions": "2478",
          "uniqueSessions": "1942",
          "totalPageViews": "2382",
          "totalEvents": "96"
        },
        {
          "day": "2018-12-21",
          "totalDevices": "1820",
          "uniqueDevices": "1571",
          "totalSessions": "1820",
          "uniqueSessions": "1378",
          "totalPageViews": "1707",
          "totalEvents": "113"
        },
        {
          "day": "2018-12-22",
          "totalDevices": "4",
          "uniqueDevices": "2",
          "totalSessions": "4",
          "uniqueSessions": "2",
          "totalPageViews": "4",
          "totalEvents": "0"
        }
      ]
    },
    {
      "periodStart": "2018-12-25",
      "periodEnd": "2018-12-31",
      "data": []
    },
    {
      "periodStart": "2018-12-31",
      "periodEnd": "2019-01-06",
      "data": []
    }
  ],
  [
    {
      "periodStart": "2018-12-19",
      "periodEnd": "2018-12-25",
      "data": [
        {
          "day": "2018-12-19",
          "totalDevices": "2676",
          "uniqueDevices": "2301",
          "totalSessions": "2676",
          "uniqueSessions": "2034",
          "totalPageViews": "2518",
          "totalEvents": "158"
        },
        {
          "day": "2018-12-20",
          "totalDevices": "2478",
          "uniqueDevices": "2186",
          "totalSessions": "2478",
          "uniqueSessions": "1942",
          "totalPageViews": "2382",
          "totalEvents": "96"
        },
        {
          "day": "2018-12-21",
          "totalDevices": "1820",
          "uniqueDevices": "1571",
          "totalSessions": "1820",
          "uniqueSessions": "1378",
          "totalPageViews": "1707",
          "totalEvents": "113"
        },
        {
          "day": "2018-12-22",
          "totalDevices": "4",
          "uniqueDevices": "2",
          "totalSessions": "4",
          "uniqueSessions": "2",
          "totalPageViews": "4",
          "totalEvents": "0"
        }
      ]
    },
    {
      "periodStart": "2018-12-25",
      "periodEnd": "2018-12-31",
      "data": []
    },
    {
      "periodStart": "2018-12-31",
      "periodEnd": "2019-01-06",
      "data": []
    }
  ],
  [
    {
      "periodStart": "2018-12-19",
      "periodEnd": "2018-12-25",
      "data": [
        {
          "day": "2018-12-19",
          "totalDevices": "2676",
          "uniqueDevices": "2301",
          "totalSessions": "2676",
          "uniqueSessions": "2034",
          "totalPageViews": "2518",
          "totalEvents": "158"
        },
        {
          "day": "2018-12-20",
          "totalDevices": "2478",
          "uniqueDevices": "2186",
          "totalSessions": "2478",
          "uniqueSessions": "1942",
          "totalPageViews": "2382",
          "totalEvents": "96"
        },
        {
          "day": "2018-12-21",
          "totalDevices": "1820",
          "uniqueDevices": "1571",
          "totalSessions": "1820",
          "uniqueSessions": "1378",
          "totalPageViews": "1707",
          "totalEvents": "113"
        },
        {
          "day": "2018-12-22",
          "totalDevices": "4",
          "uniqueDevices": "2",
          "totalSessions": "4",
          "uniqueSessions": "2",
          "totalPageViews": "4",
          "totalEvents": "0"
        }
      ]
    },
    {
      "periodStart": "2018-12-25",
      "periodEnd": "2018-12-31",
      "data": []
    },
    {
      "periodStart": "2018-12-31",
      "periodEnd": "2019-01-06",
      "data": []
    }
  ]
]
```

Data structure for `last 24 hours`:
```
[
  {
    "metricActiveDevicesPrior": 0,
    "metricActiveDevices": 0
  },
  {
    "metricNewDevicesPrior": 0,
    "metricNewDevices": 0
  },
  [
    {
      "periodStart": "2018-12-31T10:21:51+00:00",
      "periodEnd": "2019-01-01T10:21:51+00:00",
      "count": 0
    },
    {
      "periodStart": "2019-01-01T10:21:51+00:00",
      "periodEnd": "2019-01-02T10:21:51+00:00",
      "count": 0
    }
  ],
  [
    {
      "periodStart": "2018-12-31T10:21:51+00:00",
      "periodEnd": "2019-01-01T10:21:51+00:00",
      "count": 0
    },
    {
      "periodStart": "2019-01-01T10:21:51+00:00",
      "periodEnd": "2019-01-02T10:21:51+00:00",
      "count": 0
    }
  ],
  [
    {
      "periodStart": "2018-12-31T10:21:51+00:00",
      "periodEnd": "2019-01-01T10:21:51+00:00",
      "count": 0
    },
    {
      "periodStart": "2019-01-01T10:21:51+00:00",
      "periodEnd": "2019-01-02T10:21:51+00:00",
      "count": 0
    }
  ]
]"
```
