### PR TITLE
Bug/custom date range fix

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -96,6 +96,10 @@ body {
   cursor: pointer;
 }
 
+.timeframe-disclaimer{
+  font-size: 13px;
+}
+
 .analytics-date-range + .agenda-icon {
   margin-left: 10px;
 }

--- a/interface.html
+++ b/interface.html
@@ -9,7 +9,7 @@
   <div class="app-analytics-container">
     <div class="analytics-main-content">
       <div class="analytics-box timeframe-text">
-        <div class="analytics-box-title-span">TIMEFRAME</div>
+        <div class="analytics-box-title-span">TIMEFRAME <span class="timeframe-disclaimer">(report data is refreshed every 4 hours)</span></div>
         <div class="date-box">
           <span class="analytics-date-range">&nbsp;</span>
           <span class="fa fa-calendar agenda-icon"></span>

--- a/js/libs.js
+++ b/js/libs.js
@@ -1035,14 +1035,14 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
     var metricDevices = Fliplet.App.Analytics.Aggregate.count({
       column: 'uniqueDevices',
       from: moment(priorPeriodStartDate).format('YYYY-MM-DD'),
-      to: moment(currentPeriodStartDate).format('YYYY-MM-DD')
+      to: moment(currentPeriodStartDate).subtract(1, 'ms').format('YYYY-MM-DD')
     }).then(function(previousPeriod) {
       previousPeriodUsers = previousPeriod;
       // 2. get devices up to end of previous period
       return Fliplet.App.Analytics.Aggregate.count({
         column: 'uniqueDevices',
         from: moment(currentPeriodStartDate).format('YYYY-MM-DD'),
-        to: moment(currentPeriodEndDate).format('YYYY-MM-DD')
+        to: moment(currentPeriodEndDate).subtract(1, 'ms').format('YYYY-MM-DD')
       }).then(function(currentPeriod) {
         currentPeriodUsers = currentPeriod
         return;

--- a/js/libs.js
+++ b/js/libs.js
@@ -716,25 +716,25 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
 
   function calculateAnalyticsDatesCustom(customStartDate, customEndDate, isCustom, time, timeToGoBack) {
     if (isCustom) {
+      timeToGoBack = moment(customEndDate).diff(moment(customStartDate), 'days');
+      timeDeltaInMillisecs = customEndDate - customStartDate;
+      time = 'days';
       // Set start date
       analyticsStartDate = new Date(customStartDate);
       analyticsStartDate.setHours(0, 0, 0, 0);
+
       // Set end date
       analyticsEndDate = new Date(customEndDate);
-      analyticsEndDate.setDate(analyticsEndDate.getDate() + 1);
       analyticsEndDate.setHours(0, 0, 0, 0);
-      analyticsEndDate.setMilliseconds(analyticsEndDate.getMilliseconds() - 1);
-      // Calculates the difference between end and start dates
-      timeDeltaInMillisecs = analyticsEndDate - analyticsStartDate;
+
       // Set previous period start date
       analyticsPrevStartDate = new Date(analyticsStartDate);
-      analyticsPrevStartDate.setMilliseconds(analyticsEndDate.getMilliseconds() - timeDeltaInMillisecs);
+      analyticsPrevStartDate = moment(analyticsPrevStartDate).subtract(timeToGoBack, time).toDate();
       // Set previous period end date
-      analyticsPrevEndDate = new Date(analyticsStartDate);
-      analyticsPrevEndDate.setMilliseconds(analyticsEndDate.getMilliseconds() - timeDeltaInMillisecs);
-      // Set previous period start date
-      analyticsPrevStartDate = new Date(analyticsStartDate);
-    } else {
+      analyticsPrevEndDate = new Date(analyticsEndDate);
+      analyticsPrevEndDate = moment(analyticsPrevEndDate).subtract(timeToGoBack, time).toDate();
+    }
+    else{
       // Set start date
       analyticsStartDate = new Date(customStartDate);
       analyticsStartDate = moment(analyticsStartDate).subtract(timeToGoBack, time).toDate();
@@ -742,7 +742,7 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
       // Set end date
       analyticsEndDate = new Date(customEndDate);
       analyticsEndDate.setHours(0, 0, 0, 0);
-      analyticsEndDate.setMilliseconds(analyticsEndDate.getMilliseconds() - 1);
+      analyticsEndDate.setMilliseconds(analyticsEndDate.getMilliseconds());
       // Set previous period start date
       analyticsPrevStartDate = new Date(analyticsStartDate);
       analyticsPrevStartDate = moment(analyticsPrevStartDate).subtract(timeToGoBack, time).toDate();


### PR DESCRIPTION
Custom ranges will be handled properly now. Also the `1ms` date shifting was moved to the fetching phase so there's no mismatch between the model and the UI.
Probably fixes https://github.com/Fliplet/fliplet-studio/issues/3617#issuecomment-450986408 but will first need a dump out of the client's app to test it. @squallstar 