### PR TITLE
Bug/3663 multiple analytics cosmetic changes

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -287,7 +287,7 @@ span.analytics-box-number-prior {
   top: env(safe-area-inset-top);
   left: 0;
   transform: translate3d(100%, 0, 0);
-  padding: 30px 0px 30px;
+  padding: 20px 0px 30px;
   z-index: 11;
   transition: all 0.25s;
 }
@@ -296,7 +296,7 @@ span.analytics-box-number-prior {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 30px;
+  margin-bottom: 20px;
 }
 
 .full-screen-overlay-header .header-controls {
@@ -498,6 +498,9 @@ span.analytics-box-number-prior {
   font-size: 14px;
   line-height: 1.42857143;
   border-radius: 25px;
+  position: absolute;
+  top: -48px;
+  right: 0;
 }
 
 .app-analytics-container .dataTables_wrapper .dt-button:hover,

--- a/css/interface.css
+++ b/css/interface.css
@@ -520,7 +520,15 @@ span.analytics-box-number-prior {
   height: 34px;
   margin: 0 10px;
 }
-
+.app-analytics-container .dataTables_wrapper .filter{
+  padding-left: 5px;
+  margin-top: 5px;
+  height: 25px;
+  font-size: 12px;
+  color: gray;
+  font-weight: normal;
+  border-radius: 2px;
+}
 .app-analytics-container .dataTables_wrapper input {
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 2px;
@@ -562,7 +570,7 @@ span.analytics-box-number-prior {
 }
 
 .app-analytics-container table.dataTable.no-footer {
-  margin-top: 20px;
+  /* margin-top: 20px; */
 }
 
 .app-analytics-container .dt-button-background {

--- a/interface.html
+++ b/interface.html
@@ -250,10 +250,10 @@
           <thead>
             <tr>
               <th data-priority="1">User</th>
-              <th>Screen</th>
+              <th data-priority="2">Screen</th>
               <th>Type</th>
               <th>Event category</th>
-              <th data-priority="2">Event action</th>
+              <th data-priority="3">Event action</th>
               <th>Event label</th>
             </tr>
           </thead>

--- a/interface.html
+++ b/interface.html
@@ -68,7 +68,7 @@
               </label>
               <label class="radio-label">
                 <input type="radio" name="users-selector" value="users-clicks">
-                <span class="radio-label-btn">Clicks</span>
+                <span class="radio-label-btn">Interactions</span>
               </label>
             </form>
             <div class="analytics-row-wrapper analytics-row-wrapper-users">
@@ -92,16 +92,16 @@
             </div>
             <form class="screens-radio-selectors">
               <label class="radio-label">
-                <input type="radio" name="screen-selector" value="screens-screen-views">
-                <span class="radio-label-btn">Screen-views</span>
-              </label>
-              <label class="radio-label">
                 <input type="radio" name="screen-selector" value="screens-sessions">
                 <span class="radio-label-btn">Sessions</span>
               </label>
               <label class="radio-label">
+                <input type="radio" name="screen-selector" value="screens-screen-views">
+                <span class="radio-label-btn">Screen views</span>
+              </label>
+              <label class="radio-label">
                 <input type="radio" name="screen-selector" value="screens-clicks">
-                <span class="radio-label-btn">Clicks</span>
+                <span class="radio-label-btn">Interactions</span>
               </label>
             </form>
             <div class="analytics-row-wrapper analytics-row-wrapper-screen">
@@ -112,7 +112,7 @@
             </div>
           </div>
           <div class="analytics-box actions-by-screen">
-            <span class="analytics-box-title-span">ACTIONS PER SCREEN</span>
+            <span class="analytics-box-title-span">INTERACTIONS PER SCREEN</span>
             <div class="see-more inline more-actions-by-screen">See all
               <span class="fa fa-long-arrow-right"></span>
             </div>
@@ -212,7 +212,7 @@
         <table class="display responsive active-users-full-table-sessions" width="100%">
           <thead>
             <tr>
-              <th data-priority="1">User email</th>
+              <th data-priority="1">User</th>
               <th>Sessions</th>
             </tr>
           </thead>
@@ -220,7 +220,7 @@
         <table class="display responsive hidden active-users-full-table-views" width="100%">
           <thead>
             <tr>
-              <th data-priority="1">User email</th>
+              <th data-priority="1">User</th>
               <th>Screen views</th>
             </tr>
           </thead>
@@ -228,8 +228,8 @@
         <table class="display responsive hidden active-users-full-table-clicks" width="100%">
           <thead>
             <tr>
-              <th data-priority="1">User email</th>
-              <th>Clicks</th>
+              <th data-priority="1">User</th>
+              <th>Interactions</th>
             </tr>
           </thead>
         </table>
@@ -249,11 +249,12 @@
         <table class="display responsive actions-per-user" width="100%">
           <thead>
             <tr>
-              <th data-priority="1">User email</th>
+              <th data-priority="1">User</th>
+              <th>Screen</th>
+              <th>Type</th>
               <th>Event category</th>
               <th data-priority="2">Event action</th>
               <th>Event label</th>
-              <th>Screen</th>
             </tr>
           </thead>
         </table>
@@ -290,7 +291,7 @@
           <thead>
             <tr>
               <th data-priority="1">Screen name</th>
-              <th>Clicks</th>
+              <th>Interactions</th>
             </tr>
           </thead>
         </table>
@@ -303,7 +304,7 @@
           <div class="close-button">
             <span class="fa fa-angle-left"></span>
           </div>
-          <div class="header-title">ACTIONS PER SCREEN</div>
+          <div class="header-title">INTERACTIONS PER SCREEN</div>
         </div>
       </div>
       <div class="options-wrapper">


### PR DESCRIPTION
Added 500 limit on table
excel button text change: export visible entries to Excel
fixed header on table
fixed pagination at bottom
remove frontend mapping on action/category
add type on table
reorder columns: user, screen, type, event category, action, label
undefined to show as an empty string
type query should have a "app.analytics." prefix in the query to make sure only analytics logs can be searched
actions per screen to be renamed to interactions per screen
rename "Clicks" to "Interactions"
"Screen-views" "Screen views" naming consistency
Tabs to be ordered all the same across different sections
investigate on advanced search to specify column for each search input (edited)

Ref. https://github.com/Fliplet/fliplet-studio/issues/3663