### PR TITLE
Date range reset logic

### DIFF
--- a/js/libs.js
+++ b/js/libs.js
@@ -634,6 +634,7 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
     // save dates to a persistant variable
     pvDateTimeObject = {
       dateSelectMode: dateSelectMode || 'last-7-days',
+      lastAccessedAt: new Date().getTime(),
       sd: analyticsStartDate,
       ed: analyticsEndDate,
       psd: analyticsPrevStartDate,
@@ -649,7 +650,7 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
     // get dates and times
     Fliplet.Storage.get('analytics-' + appId + '-dateTime')
       .then(function(analyticsDateTime) {
-        if (analyticsDateTime) {
+        if (analyticsDateTime && moment(new Date()).diff(moment(analyticsDateTime.lastAccessedAt), 'days') < 1) {
           pvDateTimeObject = analyticsDateTime;
           dateSelectMode = pvDateTimeObject.dateSelectMode;
           analyticsStartDate = new Date(pvDateTimeObject.sd);


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/3652
Date range will be reset to last-7-days when analytics hasn't been accessed in more than a day.
Basically, every time the report viewer is accessed, we store the `lastAccessedAt` timestamp in PV. 
Every time PV is accessed, we check for that flag and if it was over a day ago, we just bail out to the server call.