### PR TITLE
Ensures all counts are formatted correctly with commas

### DIFF
--- a/js/libs.js
+++ b/js/libs.js
@@ -363,6 +363,10 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
 
   function registerHandlebarsHelpers() {
     Handlebars.registerHelper('formatNumber', function(num) {
+      if (typeof num === 'string' && parseInt(num, 10) + '' === num) {
+        num = parseInt(num, 10);
+      }
+
       if (isNaN(num)) {
         return;
       }


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/4183#issuecomment-482388077

Looks like the `app/:id/analytics` endpoint doesn't always return the count as a number. Sometimes it's returned as a string. This ensures strings are formatted correctly and resolves the inconsistency in the commas shown below.

![image](https://user-images.githubusercontent.com/290733/56042600-5c9cb580-5d33-11e9-9735-af9b6882eac9.png)

A sample request where the API returns the count as a string can be found below.

```
curl 'https://us.api.fliplet.com/v1/apps/1146/analytics' -H 'Origin: https://us.api.fliplet.com' -H 'DNT: 1' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36' -H 'Content-Type: application/json' -H 'Accept: */*' -H 'X-Device-Tracking: {"uuid":"66ef974d-1bef-46fa-bcb8-3ee6b28bd08d","model":"Browser","platform":"MacIntel","manufacturer":"Web","version":1,"width":815,"height":1588}' -H 'Referer: https://us.api.fliplet.com/v1/widgets/com.fliplet.analytics-report-provider/interface?organizationId=505&appId=1146&providerMode=inline' -H 'X-Requested-With: XMLHttpRequest' -H 'Auth-token: us--session--a03fef4371bb62d024cc2709f183134a-090-068-5005' --data-binary '{"source":"production","group":"user","sum":"totalEvents","order":[["count","DESC"]],"limit":5,"from":"2019-04-05","to":"2019-04-12"}' --compressed
```