### PR TITLE
Data tables autoresizing now works correctly

### DIFF
--- a/js/libs.js
+++ b/js/libs.js
@@ -1484,9 +1484,9 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
       });
       renderColumnFilters(actionsPerUserTable);
     }
-    setTimeout(function(){
+    setTimeout(function() {
       Fliplet.Studio.emit('widget-autosize', {
-        height: $('.dataTables_wrapper').outerHeight() + DATATABLE_HEADER_AND_FOOTER_HEIGHT
+        height: $('.full-screen-overlay.active').find('.dataTables_wrapper').outerHeight() + DATATABLE_HEADER_AND_FOOTER_HEIGHT
       });
     }, 1000);
   }
@@ -1596,9 +1596,9 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
       });
       renderColumnFilters(actionsPerScreenTable);
     }
-    setTimeout(function(){
+    setTimeout(function() {
       Fliplet.Studio.emit('widget-autosize', {
-        height: $('.dataTables_wrapper').outerHeight() + DATATABLE_HEADER_AND_FOOTER_HEIGHT
+        height: $('.full-screen-overlay.active').find('.dataTables_wrapper').outerHeight() + DATATABLE_HEADER_AND_FOOTER_HEIGHT
       });
     }, 1000);
   }


### PR DESCRIPTION
@tonytlwu @squallstar @sofiiakvasnevska 

## Issue
Fliplet/fliplet-studio#4779

## Description
Resizing was incorrect because there could be more than 1 class "dataTables_wrapper". Now it resizing looks for this class in the active overlay.

## Screenshots/screencasts
![tabs fix (1)](https://user-images.githubusercontent.com/52824207/68377012-50a29600-0152-11ea-9aa0-75d197b008ab.gif)

## Backward compatibility
This change is fully backward compatible.