### PR TITLE
Years, decades, centuries do not overlap each other in date picker menu for custom dates

### DIFF
--- a/vendor/bootstrap-datepicker3.css
+++ b/vendor/bootstrap-datepicker3.css
@@ -81,6 +81,11 @@
   -ms-user-select: none;
   user-select: none;
 }
+.datepicker-years,
+.datepicker-decades,
+.datepicker-centuries {
+  min-width: 250px;
+}
 .datepicker table tr td,
 .datepicker table tr th {
   text-align: center;

--- a/vendor/bootstrap-datepicker3.css
+++ b/vendor/bootstrap-datepicker3.css
@@ -81,10 +81,13 @@
   -ms-user-select: none;
   user-select: none;
 }
+.datepicker-months {
+  min-width: 235px;
+}
 .datepicker-years,
 .datepicker-decades,
 .datepicker-centuries {
-  min-width: 250px;
+  min-width: 280px;
 }
 .datepicker table tr td,
 .datepicker table tr th {
@@ -685,4 +688,3 @@ fieldset[disabled] .datepicker table tr td span.active.disabled:hover.focus {
   margin-left: -5px;
   margin-right: -5px;
 }
-/*# sourceMappingURL=bootstrap-datepicker3.css.map */


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4976

## Description
Added min-width to years, decades, centuries datepicker.

## Screenshots/screencasts
New look:
![years](https://user-images.githubusercontent.com/52824207/70918643-13baa080-2028-11ea-87e9-c8ee3d43fec7.PNG)
![decades](https://user-images.githubusercontent.com/52824207/70918637-11584680-2028-11ea-8651-9d67f4c1c3cd.PNG)
![centuries](https://user-images.githubusercontent.com/52824207/70918629-0ef5ec80-2028-11ea-8bf5-4a5652ece703.PNG)

## Backward compatibility
This change is fully backward compatible.