### PR TITLE
End date error message is shown correctly

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -387,6 +387,10 @@ span.analytics-box-number-prior {
   background: #333333;
 }
 
+.app-analytics-container .custom-dates-hidden-content {
+  display: inline-block;
+}
+
 .app-analytics-container .datepicker {
   background-color: transparent;
   border: none;


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4987

## Description
Changed display: block default property to display: inline-block.

## Screenshots/screencasts
![analitycs-error-demo](https://user-images.githubusercontent.com/52824207/70919374-6f395e00-2029-11ea-82f8-8cb9518c499a.gif)

## Backward compatibility
This change is fully backward compatible.