### PR TITLE
Date validator works when user manually enter date in input

### DIFF
--- a/js/libs.js
+++ b/js/libs.js
@@ -392,7 +392,7 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
       autoclose: true
     });
     // custom dates start-date validation
-    $container.find('.pickerStartDate').datepicker().on('changeDate', function(e) {
+    $container.find('.pickerStartDate').datepicker().on('hide changeDate', function(e) {
       // if start date exists check end date is after start date
       if (typeof $('.pickerEndDate').data('datepicker').dates[0] === 'undefined') {
         $('.custom-start-date-alert').removeClass('active');
@@ -409,7 +409,7 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
       }
     });
     // custom dates end-date validation
-    $container.find('.pickerEndDate').datepicker().on('changeDate', function(e) {
+    $container.find('.pickerEndDate').datepicker().on('hide changeDate', function(e) {
       // if start date exists check end date is after start date
       if (typeof $container.find('.pickerStartDate').data('datepicker').dates[0] === 'undefined') {
         $container.find('.custom-end-date-alert').removeClass('active');


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4987

## Description
Now validation event triggers also when datepicker modal is closed. So if the user enters the date manually it will be validated. 

## Screenshots/screencasts
![analytics-fix](https://user-images.githubusercontent.com/52824207/71722181-b0ef4480-2e30-11ea-9aa9-fc7ee38c769d.gif)

## Backward compatibility
This change is fully backward compatible.