### PR TITLE
Processing text now is visible and background opacity is reduced

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -577,6 +577,17 @@ span.analytics-box-number-prior {
   display: none !important;
 }
 
+.app-analytics-container .dataTables_wrapper .dataTables_processing {
+  background: rgba(255, 255, 255, 0.9);
+  height: 100%;
+  left: 0;
+  margin: auto;
+  padding-top: 25%;
+  position: absolute;
+  top: 0;
+  z-index: 1;
+}
+
 .loader {
   transition: bottom 0.25s;
   pointer-events: none;


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
Fliplet/fliplet-studio#6224

## Description
The library we use for analytics (https://datatables.net/) does not support any styling of "processing" text. The solution we came up with is to make "processing" text block occupy all area and reduce background opacity by adding rgba(255, 255, 255, 0.9);

## Screenshots/screencasts
![analytics-pic](https://user-images.githubusercontent.com/52824207/80114918-cb3e6100-858c-11ea-99ef-a278da1c44d6.PNG)

video
https://streamable.com/yhmpwf

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko @YaroslavOvdii