### PR TITLE
Removed extra blank space in Analytics section

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -7,7 +7,9 @@ var data = Fliplet.Widget.getData(widgetId) || {};
 var element = $('.app-analytics-container');
 
 window.addEventListener('resize', function() {
-  Fliplet.Widget.autosize();
+  if (!$('body').hasClass('freeze')) {
+    Fliplet.Widget.autosize();
+  }
 });
 
 // Sample implementation to initialise the widget


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6367

## Description
The issue occurred because of Fliplet.Widget.autosize() ran also when opening the Analytics section and gave body incorrect height. Now it will run only when the user goes to the main Analytics page.
![analytics-main](https://user-images.githubusercontent.com/52824207/81651837-a1fe4b80-943b-11ea-8fe5-71620b7a5ac3.PNG)

## Screenshots/screencasts
https://streamable.com/c2zflo

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko