### PR TITLE
[Fix] Set Monday as the beginning of week

### DIFF
--- a/js/libs.js
+++ b/js/libs.js
@@ -325,6 +325,7 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
       endDate: '0d',
       container: '.date-picker',
       orientation: 'left',
+      weekStart: 1,
       autoclose: true
     });
     // custom dates start-date validation


### PR DESCRIPTION
Most of our analytics and reports (internal and external) use Monday as the start of week, as it is with the regions for most customer organisations. I don't think we used Sunday intentionally as the start of the week as much as we simply didn't use the parameter `weekStart` at all.

**Before**

![image](https://user-images.githubusercontent.com/290733/84005096-7c922e00-a964-11ea-8255-8316146a2272.png)

**After**

![image](https://user-images.githubusercontent.com/290733/84005053-6c7a4e80-a964-11ea-9e62-8c4962cea85d.png)
