### PR TITLE
[Maintenance] Ensures date format doesn't change when date locales become available

### DIFF
--- a/js/libs.js
+++ b/js/libs.js
@@ -1717,7 +1717,7 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
       '[name="screen-selector"][value="screens-sessions"]'
     ].join(', ');
 
-    moment.locale('en-GB');
+    moment.locale('en');
 
     registerHandlebarsHelpers();
     attachEventListeners();

--- a/js/libs.js
+++ b/js/libs.js
@@ -701,7 +701,9 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
 
   function updateTimeframe(startDate, endDate) {
     // Make the dates readable
-    $container.find('.analytics-date-range').html(moment(startDate).format('D MMM \'YY') + ' - ' + moment(endDate).format('D MMM \'YY'));
+    var longDateFormat = 'D MMM \'YY';
+
+    $container.find('.analytics-date-range').html(moment(startDate).format(longDateFormat) + ' - ' + moment(endDate).format(longDateFormat));
   }
 
   function getNewDataToRender(context, limit) {
@@ -1714,6 +1716,8 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
       '[name="users-selector"][value="users-sessions"]',
       '[name="screen-selector"][value="screens-sessions"]'
     ].join(', ');
+
+    moment.locale('en-GB');
 
     registerHandlebarsHelpers();
     attachEventListeners();


### PR DESCRIPTION
Keep date format as `en` until localisation is properly rolled out

Required for https://github.com/Fliplet/fliplet-api/pull/4149