### PR TITLE
ID-445 [Chore] Query updates for devices count

### DIFF
--- a/js/libs.js
+++ b/js/libs.js
@@ -1013,17 +1013,17 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
       };
     });
 
-    // Get new devices
+    // Get new devices up to start of previous period
     var metricNewDevices = Fliplet.App.Analytics.Aggregate.count({
       source: source,
       column: 'uniqueDevices',
-      to: priorPeriodStartDate
+      to: moment(priorPeriodStartDate).subtract(1, 'ms').format('YYYY-MM-DD')
     }).then(function(countUpToStartOfPriorPeriod) {
       // 2. get devices up to end of previous period
       return Fliplet.App.Analytics.Aggregate.count({
         source: source,
         column: 'uniqueDevices',
-        to: currentPeriodStartDate
+        to: moment(currentPeriodStartDate).subtract(1, 'ms').format('YYYY-MM-DD')
       }).then(function(countUpToStartOfCurrentPeriod) {
         previousPeriodNewUsers = countUpToStartOfCurrentPeriod - countUpToStartOfPriorPeriod;
 


### PR DESCRIPTION
Queries for "New devices" are currently skewed by one day if compared to the selected current period and previous period.

I addressed this like it was done a few lines before my patch to shift the dates to one day before, e.g. https://github.com/Fliplet/fliplet-widget-analytics-report-provider/pull/41/files#diff-e9638f5b1766fc565a3b831be67d7a18f58d5544eca6485f135f035b519d8fdbR996