### PR TITLE
[Maintenance] Initialize Tag Manager to run experiments

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1,3 +1,7 @@
+// To run experiment
+// To be removed once experiment is over
+Fliplet.TagManager.init();
+
 // Include your namespaced libraries
 var AnalyticsReport = new Fliplet.Registry.get('comflipletanalytics-report:1.0:core');
 var analyticsReports = [];


### PR DESCRIPTION
- Initialize Tag Manager to run experiments
  - This will be reverted once the experiment is over