### PR TITLE
PS-1140 [Fix] Ensures correct custom dates are passed for fetching logs

### DIFF
--- a/js/libs.js
+++ b/js/libs.js
@@ -513,8 +513,6 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
               .endOf('day')
               .format('YYYY-MM-DD HH:mm:ss[Z]');
 
-            console.log('customStartDateVariable', customStartDateVariable);
-            console.log('customEndDateVariable', customEndDateVariable);
             if (typeof customStartDateVariable === 'undefined') {
               $(this).parents('.date-picker').find('.custom-dates-inputs').css({ height: 'auto' });
               $(this).parents('.date-picker').find('.custom-start-date-alert').addClass('active');

--- a/js/libs.js
+++ b/js/libs.js
@@ -503,7 +503,8 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
           case 'custom-dates':
             customStartDateVariable = moment($(this).parents('.date-picker').find('.pickerStartDate').data('datepicker').dates[0]).utc().format('YYYY-MM-DD');
             customEndDateVariable = moment($(this).parents('.date-picker').find('.pickerEndDate').data('datepicker').dates[0]).utc().format('YYYY-MM-DD');
-
+            console.log('customStartDateVariable', customStartDateVariable);
+            console.log('customEndDateVariable', customEndDateVariable);
             if (typeof customStartDateVariable === 'undefined') {
               $(this).parents('.date-picker').find('.custom-dates-inputs').css({ height: 'auto' });
               $(this).parents('.date-picker').find('.custom-start-date-alert').addClass('active');
@@ -730,27 +731,6 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
   }
 
   function getDataFromPersistentVariable() {
-    if (configuration.startDate && configuration.endDate) {
-      dateSelectMode = 'custom-dates';
-      $('[name="date-selector"][value="custom-dates"]').prop('checked', true);
-
-      // Show custom date inputs
-      $('.custom-dates-inputs').css('height', 'auto');
-
-      // Set date picker values
-      var startDate = moment(configuration.startDate).toDate();
-      var endDate = moment(configuration.endDate).toDate();
-      $('.pickerStartDate').datepicker('update', startDate);
-      $('.pickerEndDate').datepicker('update', endDate);
-      $container.find('.apply-button').prop('disabled', false);
-
-      calculateAnalyticsDatesCustom(configuration.startDate, configuration.endDate);
-      updateTimeframe(analyticsStartDate, analyticsEndDate);
-      getNewDataToRender('day', 5);
-
-      return;
-    }
-
     // get dates and times
     Fliplet.App.Storage.get(DATE_STORE_KEY)
       .then(function(analyticsDateTime) {
@@ -1843,8 +1823,7 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
     try {
       const data = await fetchingFunction({...xhrOptions, limit: false, offset: 0, format: 'csv'}, { processData: false}).catch(function(error) {
         // parsererror is returned when the response is not a valid JSON, and it's expected for CSV responses
-        // error with statusText "OK" is an edge case, happening in some browsers; it shouldn't be an error
-        if (error.statusText === 'parsererror' || error.statusText === 'OK')  {
+        if (error.statusText === 'parsererror') {
           return error.responseText;
         }
         console.error('Error fetching table data', error);

--- a/js/libs.js
+++ b/js/libs.js
@@ -1851,6 +1851,7 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
     try {
       const data = await fetchingFunction({...xhrOptions, limit: false, offset: 0, format: 'csv'}, { processData: false}).catch(function(error) {
         // parsererror is returned when the response is not a valid JSON, and it's expected for CSV responses
+        // error with statusText "OK" is an edge case, happening in some browsers; it shouldn't be an error
         if (error.statusText === 'parsererror' || error.statusText === 'OK')  {
           return error.responseText;
         }

--- a/js/libs.js
+++ b/js/libs.js
@@ -501,8 +501,18 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
             closeOverlay();
             break;
           case 'custom-dates':
-            customStartDateVariable = moment($(this).parents('.date-picker').find('.pickerStartDate').data('datepicker').dates[0]).utc().format('YYYY-MM-DD');
-            customEndDateVariable = moment($(this).parents('.date-picker').find('.pickerEndDate').data('datepicker').dates[0]).utc().format('YYYY-MM-DD');
+            // Get start date and set to start of day (00:00:00)
+            customStartDateVariable = moment($(this).parents('.date-picker').find('.pickerStartDate').data('datepicker').dates[0])
+              .utc()
+              .startOf('day')
+              .format('YYYY-MM-DD HH:mm:ss');
+
+            // Get end date and set to end of day (23:59:59)
+            customEndDateVariable = moment($(this).parents('.date-picker').find('.pickerEndDate').data('datepicker').dates[0])
+              .utc()
+              .endOf('day')
+              .format('YYYY-MM-DD HH:mm:ss');
+
             console.log('customStartDateVariable', customStartDateVariable);
             console.log('customEndDateVariable', customEndDateVariable);
             if (typeof customStartDateVariable === 'undefined') {

--- a/js/libs.js
+++ b/js/libs.js
@@ -501,17 +501,17 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
             closeOverlay();
             break;
           case 'custom-dates':
-            // Get start date and set to start of day (00:00:00)
+                        // Get start date and set to start of day (00:00:00)
             customStartDateVariable = moment($(this).parents('.date-picker').find('.pickerStartDate').data('datepicker').dates[0])
               .utc()
               .startOf('day')
-              .format('YYYY-MM-DD HH:mm:ss');
+              .format('YYYY-MM-DD HH:mm:ss[Z]');
 
             // Get end date and set to end of day (23:59:59)
             customEndDateVariable = moment($(this).parents('.date-picker').find('.pickerEndDate').data('datepicker').dates[0])
               .utc()
               .endOf('day')
-              .format('YYYY-MM-DD HH:mm:ss');
+              .format('YYYY-MM-DD HH:mm:ss[Z]');
 
             console.log('customStartDateVariable', customStartDateVariable);
             console.log('customEndDateVariable', customEndDateVariable);

--- a/js/libs.js
+++ b/js/libs.js
@@ -739,6 +739,26 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
   }
 
   function getDataFromPersistentVariable() {
+    if (configuration.startDate && configuration.endDate) {
+      dateSelectMode = 'custom-dates';
+      $('[name="date-selector"][value="custom-dates"]').prop('checked', true);
+
+      // Show custom date inputs
+      $('.custom-dates-inputs').css('height', 'auto');
+
+      // Set date picker values
+      var startDate = moment(configuration.startDate).toDate();
+      var endDate = moment(configuration.endDate).toDate();
+      $('.pickerStartDate').datepicker('update', startDate);
+      $('.pickerEndDate').datepicker('update', endDate);
+      $container.find('.apply-button').prop('disabled', false);
+
+      calculateAnalyticsDatesCustom(configuration.startDate, configuration.endDate);
+      updateTimeframe(analyticsStartDate, analyticsEndDate);
+      getNewDataToRender('day', 5);
+
+      return;
+    }
     // get dates and times
     Fliplet.App.Storage.get(DATE_STORE_KEY)
       .then(function(analyticsDateTime) {

--- a/js/libs.js
+++ b/js/libs.js
@@ -1851,7 +1851,7 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
     try {
       const data = await fetchingFunction({...xhrOptions, limit: false, offset: 0, format: 'csv'}, { processData: false}).catch(function(error) {
         // parsererror is returned when the response is not a valid JSON, and it's expected for CSV responses
-        if (error.statusText === 'parsererror') {
+        if (error.statusText === 'parsererror' || error.statusText === 'OK')  {
           return error.responseText;
         }
         console.error('Error fetching table data', error);


### PR DESCRIPTION
### Product areas affected

1. js/libs.js

### What does this PR do?

Updated the custom date picker functionality in the analytics widget to include precise time boundaries and UTC timezone indication.

### JIRA ticket

[PS-1140](https://weboo.atlassian.net/browse/PS-1140)

### QA Test plan

Please test below scenario

1. Actions per user Table-> Please verify data before deployment & after deployment  -> Table must contains to date data as well
3. Interactions per screen Table-> Please verify data before deployment & after deployment -> Table must contains to date data as well

[PS-1140]: https://weboo.atlassian.net/browse/PS-1140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom date selections in the date picker now include full day time ranges, ensuring start dates begin at 00:00:00 and end dates finish at 23:59:59 in UTC.

* **Style**
  * Removed an unnecessary blank line to improve code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->