### PR TITLE
Improve error UX by reopening date picker

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -643,3 +643,27 @@ span.analytics-box-number-prior {
 .btn-round {
   border-radius: 25px;
 }
+
+.date-picker .error-container {
+  display: none;
+  text-align: center;
+  margin-top: 20px;
+}
+
+.date-picker .error-container p {
+  margin-bottom: 10px;
+  color: #c00;
+}
+
+.date-picker .error-container .retry-button {
+  font-size: 14px;
+  padding: 8px 15px;
+  border-radius: 20px;
+  border: 1px solid rgba(21, 60, 73, 0.2);
+  cursor: pointer;
+  display: inline-block;
+}
+
+.date-picker.has-error .error-container {
+  display: block;
+}

--- a/interface.html
+++ b/interface.html
@@ -189,6 +189,10 @@
         </div>
         <div class="apply-button">APPLY</div>
       </div>
+      <div class="error-container">
+        <p>Error loading analytics data.</p>
+        <div class="retry-button">Retry</div>
+      </div>
       <div class="options-wrapper">
         <div class="options-row">
           <label class="radio-label">


### PR DESCRIPTION
## Summary
- display error message inside the timeframe overlay
- open the date picker when data fails to load
- allow retrying data load from the error message
- clear error message when closing the date picker or picking another date

## Testing
- `npm test` *(fails: Missing script)*
- `npx eslint .` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_686a89822db4832594f7d9ea6d5905ef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user-friendly error messages and a retry button to the analytics date picker when data fails to load.
  * The interface now clearly displays errors and allows users to retry loading analytics data directly from the overlay.

* **Style**
  * Introduced new styles for error messages and the retry button within the date picker overlay for improved visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->