### PR TITLE
[PS-1690] Use master app source for notification analytics count

### DIFF
--- a/js/libs.js
+++ b/js/libs.js
@@ -1370,7 +1370,7 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
 
   async function getCommunicationData(currentPeriodStartDate, currentPeriodEndDate ) {
     const { logs } = await Fliplet.App.Analytics.Aggregate.get({
-      source: 'master', //Changes for https://weboo.atlassian.net/browse/PS-1690. Notifications are sent using masterAppId, and logs are also created against the master app. So to fetch the notification count, we need to pull the data for the master app (not the production app).
+      source: 'master', //// Notifications are logged against the master app, not production
       from: currentPeriodStartDate,
       to: currentPeriodEndDate,
       includeCount: true,

--- a/js/libs.js
+++ b/js/libs.js
@@ -1370,7 +1370,7 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
 
   async function getCommunicationData(currentPeriodStartDate, currentPeriodEndDate ) {
     const { logs } = await Fliplet.App.Analytics.Aggregate.get({
-      source,
+      source: 'master', //Changes for https://weboo.atlassian.net/browse/PS-1690. Notifications are sent using masterAppId, and logs are also created against the master app. So to fetch the notification count, we need to pull the data for the master app (not the production app).
       from: currentPeriodStartDate,
       to: currentPeriodEndDate,
       includeCount: true,


### PR DESCRIPTION
### Product areas affected
Analytics Report Provider — communication/notification data retrieval

### What does this PR do?
Updates the `getCommunicationData` function to use `'master'` as the source when fetching notification analytics counts. Notifications are sent using the master app ID and logs are recorded against the master app, so the analytics query needs to pull data from the master app rather than the production app.

### JIRA ticket
[PS-1690](https://weboo.atlassian.net/browse/PS-1690)

### Result
Notification counts in the analytics report will now correctly reflect data from the master app source.

### Checklist
 - [ ] Added automated test coverage as appropriate for this change.

### Deployment instructions
No special deployment instructions required.

### Author concerns
The `source` is hardcoded to `'master'` specifically for the communication data query. Other analytics queries in this file continue to use the dynamic `source` variable.

[PS-1690]: https://weboo.atlassian.net/browse/PS-1690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ