### PR TITLE
feat: rename App metrics → Metrics (v3 user-visible wording)

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -71,7 +71,7 @@
           </div>
         </div>
 
-        <div class="analytics-box-container">
+        <div class="analytics-box-container analytics-users-section">
           <div class="analytics-box">
             <div style="display: flex; justify-content: space-between; align-items: center;">
               <div class="analytics-box-title-block">Most active users</div>

--- a/interface.html
+++ b/interface.html
@@ -45,7 +45,7 @@
 
         <div class="analytics-box-container">
           <div class="analytics-box">
-            <div class="analytics-box-title-block">App metrics</div>
+            <div class="analytics-box-title-block">Metrics</div>
             <div class="analytics-title-row">
               <div class="analytics-title-metric">Metric</div>
               <div class="analytics-title-prior-period">Prior period</div>

--- a/js/libs.js
+++ b/js/libs.js
@@ -1083,18 +1083,28 @@ Fliplet.Registry.set('comflipletanalytics-report:1.0:core', function(element, da
 
 
     // RENDER MOST ACTIVE USERS
-    switch ($container.find('[name="users-selector"]:checked').val()) {
-      case 'users-sessions':
-        $container.find('.analytics-row-wrapper-users').html(compiledActiveUserTemplate(pvDataArray.activeUserData.map(({ userEmail, uniqueSessions }) => ({ userEmail, count: uniqueSessions }))));
-        break;
-      case 'users-screen-views':
-        $container.find('.analytics-row-wrapper-users').html(compiledActiveUserTemplate(pvDataArray.activeUserData.map(({ userEmail, totalPageViews }) => ({ userEmail, count: totalPageViews }))));
-        break;
-      case 'users-clicks':
-        $container.find('.analytics-row-wrapper-users').html(compiledActiveUserTemplate(pvDataArray.activeUserData.map(({ userEmail, totalEvents }) => ({ userEmail, count: totalEvents }))));
-        break;
-      default:
-        break;
+    // Hide users section if no user data (app has no login functionality)
+    var hasUserData = pvDataArray.activeUserData && pvDataArray.activeUserData.length > 0;
+
+    if (hasUserData) {
+      $container.find('.analytics-users-section').show();
+
+      switch ($container.find('[name="users-selector"]:checked').val()) {
+        case 'users-sessions':
+          $container.find('.analytics-row-wrapper-users').html(compiledActiveUserTemplate(pvDataArray.activeUserData.map(({ userEmail, uniqueSessions }) => ({ userEmail, count: uniqueSessions }))));
+          break;
+        case 'users-screen-views':
+          $container.find('.analytics-row-wrapper-users').html(compiledActiveUserTemplate(pvDataArray.activeUserData.map(({ userEmail, totalPageViews }) => ({ userEmail, count: totalPageViews }))));
+          break;
+        case 'users-clicks':
+          $container.find('.analytics-row-wrapper-users').html(compiledActiveUserTemplate(pvDataArray.activeUserData.map(({ userEmail, totalEvents }) => ({ userEmail, count: totalEvents }))));
+          break;
+        default:
+          break;
+      }
+    } else {
+      // Hide the entire users section when there's no login/user data
+      $container.find('.analytics-users-section').hide();
     }
 
     // RENDER MOST POPULAR SCREENS


### PR DESCRIPTION
## Summary

User-visible "Apps → Projects" rename to align with the v3 Studio rename shipped in Fliplet/fliplet-studio#8518.

## Scope (1 string)

- `interface.html:48`: section heading `App metrics` → `Metrics` (the qualifier is dropped; reads cleanly next to the parallel "Session metrics", "Most active users", "Most popular screens", "Communication", "Technology" sections)

Includes a clean merge of `origin/production`.

## What was kept

- All `app.analytics.event` / `app.analytics.pageView` log type identifiers (data source filter values)
- GA event categories (`category: 'app_analytics'`)
- CSS classes (`.app-analytics-container`, `.analytics-row-wrapper-app-metrics`)
- `name: 'app-analytics'` overlay-scroll-top event
- `group: 'app'` Fliplet.App.Analytics.Aggregate.get parameter
- All JS identifiers (`renderAppMetrics`, `appMetrics`, `appMetricTitles`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)