### PR TITLE
feat: rename App metrics → Metrics (v3 user-visible wording)

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -45,7 +45,7 @@
 
         <div class="analytics-box-container">
           <div class="analytics-box">
-            <div class="analytics-box-title-block">App metrics</div>
+            <div class="analytics-box-title-block">Metrics</div>
             <div class="analytics-title-row">
               <div class="analytics-title-metric">Metric</div>
               <div class="analytics-title-prior-period">Prior period</div>


### PR DESCRIPTION
## Summary

Replaces #88 with a clean branch based directly on `production`. Same rename, but without the unrelated master-only commits (PS-1113 hide-users-section, DEV-764 release merge) that were pulled in by the previous branch.

User-visible "Apps → Projects" rename to align with the v3 Studio rename shipped in Fliplet/fliplet-studio#8518.

## Scope (1 string)

- `interface.html:48`: section heading `App metrics` → `Metrics` (the qualifier is dropped; reads cleanly next to the parallel "Session metrics", "Most active users", "Most popular screens", "Communication", "Technology" sections)

## What was kept

- All `app.analytics.event` / `app.analytics.pageView` log type identifiers (data source filter values)
- GA event categories (`category: 'app_analytics'`)
- CSS classes (`.app-analytics-container`, `.analytics-row-wrapper-app-metrics`)
- `name: 'app-analytics'` overlay-scroll-top event
- `group: 'app'` Fliplet.App.Analytics.Aggregate.get parameter
- All JS identifiers (`renderAppMetrics`, `appMetrics`, `appMetricTitles`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)